### PR TITLE
Align backend names and namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository manages ArgoCD projects and apps declaratively via GitOps.
 - `projects/` – ArgoCD `AppProject` definitions
 - `apps/` – ArgoCD `Application` definitions
 - `manifests/` – Raw Kubernetes resources for workloads
+- `manifests/hidmo/backend/` – Backend service exposed at `api.hidmo.leultewolde.com`
 
 ## Bootstrap
 

--- a/apps/hidmo.yaml
+++ b/apps/hidmo.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hidmo-backend
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
+    targetRevision: HEAD
+    path: manifests/hidmo/backend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hidmo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/manifests/hidmo/backend/deployment.yaml
+++ b/manifests/hidmo/backend/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hidmo-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hidmo-backend
+  template:
+    metadata:
+      labels:
+        app: hidmo-backend
+    spec:
+      containers:
+        - name: hidmo-backend
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80

--- a/manifests/hidmo/backend/ingress.yaml
+++ b/manifests/hidmo/backend/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hidmo-backend
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: api.hidmo.leultewolde.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hidmo-backend
+                port:
+                  number: 80

--- a/manifests/hidmo/backend/kustomization.yaml
+++ b/manifests/hidmo/backend/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/manifests/hidmo/backend/service.yaml
+++ b/manifests/hidmo/backend/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hidmo-backend
+spec:
+  selector:
+    app: hidmo-backend
+  ports:
+    - port: 80
+      targetPort: 80
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- rename ArgoCD Application to `hidmo-backend`
- deploy backend into the `hidmo` namespace
- update Deployment and Ingress names to `hidmo-backend`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685c1d1fd924832cb398d56be78bfb98