### PR TITLE
Switch backend gateway to Kong

### DIFF
--- a/manifests/hidmo/backend/deployment.yaml
+++ b/manifests/hidmo/backend/deployment.yaml
@@ -13,7 +13,23 @@ spec:
         app: hidmo-backend
     spec:
       containers:
-        - name: hidmo-backend
-          image: nginx:1.25-alpine
+        - name: kong
+          image: kong:3.5-alpine
+          env:
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /etc/kong/kong.yml
+            - name: KONG_ADMIN_LISTEN
+              value: "0.0.0.0:8001"
+          volumeMounts:
+            - name: kong-config
+              mountPath: /etc/kong
           ports:
-            - containerPort: 80
+            - containerPort: 8000
+            - containerPort: 8443
+            - containerPort: 8001
+      volumes:
+        - name: kong-config
+          configMap:
+            name: kong-config

--- a/manifests/hidmo/backend/ingress.yaml
+++ b/manifests/hidmo/backend/ingress.yaml
@@ -2,31 +2,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hidmo-backend
-  annotations:
-    # nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
-  ingressClassName: nginx
+  ingressClassName: kong
   rules:
     - host: api-hidmo.leultewolde.com
       http:
         paths:
-          - path: /micro1(/|$)(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: micro1
-                port:
-                  number: 80
-          - path: /micro2(/|$)(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: micro2
-                port:
-                  number: 80
           - path: /
             pathType: Prefix
             backend:

--- a/manifests/hidmo/backend/kong-config.yaml
+++ b/manifests/hidmo/backend/kong-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kong-config
+  labels:
+    app: hidmo-backend
+data:
+  kong.yml: |
+    _format_version: "3.0"
+    services:
+      - name: micro1
+        url: http://micro1
+        routes:
+          - name: micro1
+            paths:
+              - /micro1
+      - name: micro2
+        url: http://micro2
+        routes:
+          - name: micro2
+            paths:
+              - /micro2

--- a/manifests/hidmo/backend/kustomization.yaml
+++ b/manifests/hidmo/backend/kustomization.yaml
@@ -2,5 +2,6 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - kong-config.yaml
   - microservices/micro1
   - microservices/micro2

--- a/manifests/hidmo/backend/service.yaml
+++ b/manifests/hidmo/backend/service.yaml
@@ -7,5 +7,5 @@ spec:
     app: hidmo-backend
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8000
   type: ClusterIP


### PR DESCRIPTION
## Summary
- replace the NGINX deployment with Kong
- add Kong configuration to route to `micro1` and `micro2`
- update service and ingress for Kong
- include the new configmap in kustomization

## Testing
- `kustomize build manifests/hidmo/backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5890f6c8832ca8f124f79f3f66ee