### PR TITLE
Fix kustomize build for postgres

### DIFF
--- a/apps/postgres.yaml
+++ b/apps/postgres.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
     targetRevision: HEAD
     path: manifests/postgres
+    kustomize:
+      # explicitly run kustomize with Helm support enabled
+      buildOptions: --enable-helm
+      enableHelm: true
   destination:
     server: https://kubernetes.default.svc
     namespace: postgres


### PR DESCRIPTION
## Summary
- enable Helm in the Postgres application by passing `--enable-helm`

## Testing
- `kustomize build manifests/postgres` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ded9d25f4832cbda00e8c8e764775