### PR TITLE
Embed postgres helm values

### DIFF
--- a/apps/postgres.yaml
+++ b/apps/postgres.yaml
@@ -10,8 +10,19 @@ spec:
     chart: postgresql
     targetRevision: 15.5.6
     helm:
-      valueFiles:
-        - manifests/postgres/values.yaml
+      values: |
+        auth:
+          username: appuser
+          database: appdb
+          existingSecret: postgres-credentials
+        primary:
+          persistence:
+            size: 1Gi
+            storageClass: standard
+          service:
+            type: LoadBalancer
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: postgres.leultewolde.com
       releaseName: postgres
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary
- embed Helm values directly in `apps/postgres.yaml`

## Testing
- `kustomize build --enable-helm manifests/postgres` *(fails: chart repository unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685f416f9de8832c95d6b570d3ab949d