### PR TITLE
Add SonarQube deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository manages ArgoCD projects and apps declaratively via GitOps.
 - `manifests/postgres/` – Holds `values.yaml` for the Bitnami PostgreSQL Helm chart and a `SealedSecret` with the database password.
 - `apps/postgres.yaml` – Deploys the chart from the Bitnami repository using that values file. The `apps/postgres-secret.yaml` application syncs the credentials first so the Helm release can succeed.
 - PostgreSQL is reachable at `postgres.leultewolde.com` for apps and tools
+- SonarQube is reachable at `sonar.leultewolde.com` with persistent storage
 
 ## Bootstrap
 

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -3,4 +3,5 @@ resources:
   - postgres.yaml
   - guestbook.yaml
   - hidmo.yaml
+  - sonarqube.yaml
 

--- a/apps/sonarqube.yaml
+++ b/apps/sonarqube.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sonarqube
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://SonarSource.github.io/helm-chart-sonarqube
+    chart: sonarqube
+    targetRevision: 2025.3.1
+    helm:
+      values: |
+        persistence:
+          enabled: true
+          storageClass: local-path
+          size: 5Gi
+        service:
+          type: LoadBalancer
+          annotations:
+            external-dns.alpha.kubernetes.io/hostname: sonar.leultewolde.com
+        postgresql:
+          enabled: true
+          persistence:
+            enabled: true
+            storageClass: local-path
+            size: 5Gi
+      releaseName: sonarqube
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: sonarqube
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- deploy SonarQube via Helm chart with persistent storage
- expose SonarQube at `sonar.leultewolde.com`
- include SonarQube application in kustomization
- document the new service in the README

## Testing
- `kubectl kustomize apps` *(fails: `kubectl` not found)*
- `yamllint -v` *(fails: `yamllint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686145ce66f0832c8b7896a2a88d9495