### PR TITLE
Fix image path for ingredients service

### DIFF
--- a/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: km-ingredients-service
-          image: ivtheforth/km-ingredients-service:latest
+          image: docker.io/ivtheforth/km-ingredients-service:latest
           ports:
             - containerPort: 7001
           env:


### PR DESCRIPTION
## Summary
- specify the full Docker registry path for `km-ingredients-service` deployment

## Testing
- `kustomize build manifests/hidmo/backend/microservices/ingredients-service`
- `yamllint manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml` *(warns: missing document start)*
- `yamllint apps/km-ingredients-service.yaml` *(errors: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_686342c1c2a0832cbf78c8cfaa1ed7f9