### PR TITLE
Restrict Kong admin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ Create a bootstrap ArgoCD `Application` pointing to the `apps/` directory.
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+## Security Notes
+
+The `hidmo-backend` deployment now binds Kong's Admin API to `127.0.0.1` so it
+cannot be reached from other pods. Only the proxy ports are exposed via the
+`hidmo-backend` service and Ingress.

--- a/manifests/hidmo/backend/deployment.yaml
+++ b/manifests/hidmo/backend/deployment.yaml
@@ -20,15 +20,15 @@ spec:
               value: "off"
             - name: KONG_DECLARATIVE_CONFIG
               value: /etc/kong/kong.yml
+            # Limit admin API to localhost so it is not reachable from other pods
             - name: KONG_ADMIN_LISTEN
-              value: "0.0.0.0:8001"
+              value: "127.0.0.1:8001"
           volumeMounts:
             - name: kong-config
               mountPath: /etc/kong
           ports:
             - containerPort: 8000
             - containerPort: 8443
-            - containerPort: 8001
       volumes:
         - name: kong-config
           configMap:


### PR DESCRIPTION
## Summary
- reduce exposure of Kong admin API in `hidmo-backend` deployment
- document the change in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68692bde2dac832cbe9803f3b4f3c30a