### PR TITLE
Add health probes for km-ingredients-service

### DIFF
--- a/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
@@ -65,3 +65,19 @@ spec:
             #     secretKeyRef:
             #       name: km-ingredients-secrets
             #       key: minio-bucket
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 7001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 7001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3


### PR DESCRIPTION
## Summary
- add HTTP liveness and readiness probes for `km-ingredients-service` deployment
- refine to use `/actuator/health/liveness` and `/actuator/health/readiness` endpoints

## Testing
- `kustomize build manifests/hidmo/backend/microservices/ingredients-service`


------
https://chatgpt.com/codex/tasks/task_e_686932b7fa64832c8c40c224e358b68e