### PR TITLE
Add staging and systemtest deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository manages ArgoCD projects and apps declaratively via GitOps.
 - PostgreSQL is reachable at `postgres.leultewolde.com` for apps and tools
 - SonarQube is reachable at `sonar.leultewolde.com` with persistent storage
 - Jenkins is reachable at `jenkins.leultewolde.com` for CI/CD pipelines
+- JFrog Artifactory is reachable at `artifactory.leultewolde.com` for storing artifacts
 - HashiCorp Vault UI is reachable at `vault.leultewolde.com` for managing secrets
 - Argo Image Updater keeps `km-ingredients-service` up to date automatically via git write-back.
 

--- a/apps/artifactory.yaml
+++ b/apps/artifactory.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: artifactory
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.jfrog.io
+    chart: artifactory
+    targetRevision: 107.111.11
+    helm:
+      values: |
+        artifactory:
+          service:
+            type: LoadBalancer
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: artifactory.leultewolde.com
+        ingress:
+          enabled: true
+          hosts:
+            - artifactory.leultewolde.com
+          annotations:
+            external-dns.alpha.kubernetes.io/hostname: artifactory.leultewolde.com
+      releaseName: artifactory
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: artifactory
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/hidmo-backend-staging.yaml
+++ b/apps/hidmo-backend-staging.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hidmo-backend-staging
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
+    targetRevision: HEAD
+    path: manifests/hidmo-staging/backend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hidmo-staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/hidmo-backend-systemtest.yaml
+++ b/apps/hidmo-backend-systemtest.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hidmo-backend-systemtest
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
+    targetRevision: HEAD
+    path: manifests/hidmo-systemtest/backend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hidmo-systemtest
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/hidmo-frontend-staging.yaml
+++ b/apps/hidmo-frontend-staging.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hidmo-frontend-staging
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
+    targetRevision: HEAD
+    path: manifests/hidmo-staging/frontend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hidmo-staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/hidmo-frontend-systemtest.yaml
+++ b/apps/hidmo-frontend-systemtest.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hidmo-frontend-systemtest
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
+    targetRevision: HEAD
+    path: manifests/hidmo-systemtest/frontend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hidmo-systemtest
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   # - hidmo.yaml
   - hidmo-backend.yaml
   - hidmo-frontend.yaml
+  - hidmo-backend-staging.yaml
+  - hidmo-frontend-staging.yaml
+  - hidmo-backend-systemtest.yaml
+  - hidmo-frontend-systemtest.yaml
   - sonarqube-secret.yaml
   - sonarqube.yaml
   # - km-ingredients-service.yaml

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - hidmo-frontend-systemtest.yaml
   - sonarqube-secret.yaml
   - sonarqube.yaml
+  - artifactory.yaml
   # - km-ingredients-service.yaml
   # - jenkins.yaml
   # - jenkins-rbac.yaml

--- a/manifests/hidmo-staging/backend/kustomization.yaml
+++ b/manifests/hidmo-staging/backend/kustomization.yaml
@@ -1,0 +1,3 @@
+namespace: hidmo-staging
+resources:
+  - ../../hidmo/backend

--- a/manifests/hidmo-staging/frontend/kustomization.yaml
+++ b/manifests/hidmo-staging/frontend/kustomization.yaml
@@ -1,0 +1,3 @@
+namespace: hidmo-staging
+resources:
+  - ../../hidmo/frontend

--- a/manifests/hidmo-systemtest/backend/kustomization.yaml
+++ b/manifests/hidmo-systemtest/backend/kustomization.yaml
@@ -1,0 +1,3 @@
+namespace: hidmo-systemtest
+resources:
+  - ../../hidmo/backend

--- a/manifests/hidmo-systemtest/frontend/kustomization.yaml
+++ b/manifests/hidmo-systemtest/frontend/kustomization.yaml
@@ -1,0 +1,3 @@
+namespace: hidmo-systemtest
+resources:
+  - ../../hidmo/frontend


### PR DESCRIPTION
## Summary
- create staging and systemtest overlay dirs
- add ArgoCD apps for staging and systemtest
- include new apps in the global kustomization

## Testing
- `kustomize build manifests/hidmo-staging/backend`
- `kustomize build manifests/hidmo-staging/frontend`
- `kustomize build manifests/hidmo-systemtest/backend`
- `kustomize build manifests/hidmo-systemtest/frontend`


------
https://chatgpt.com/codex/tasks/task_e_686d9453d530832c86a71db48e1b6a7a