### PR TITLE
Switch to official Sonatype HA chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository manages ArgoCD projects and apps declaratively via GitOps.
 - PostgreSQL is reachable at `postgres.leultewolde.com` for apps and tools
 - SonarQube is reachable at `sonar.leultewolde.com` with persistent storage
 - Jenkins is reachable at `jenkins.leultewolde.com` for CI/CD pipelines
-- Sonatype Nexus Repository OSS is reachable at `nexus.leultewolde.com` for storing artifacts via the `sonatype-nexus` Helm chart
+  - Sonatype Nexus Repository Pro is reachable at `nexus.leultewolde.com` for storing artifacts via Sonatype's `nxrm-ha` Helm chart
 - HashiCorp Vault UI is reachable at `vault.leultewolde.com` for managing secrets
 - Argo Image Updater keeps `km-ingredients-service` up to date automatically via git write-back.
 

--- a/apps/nexus.yaml
+++ b/apps/nexus.yaml
@@ -7,27 +7,33 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://oteemo.github.io/charts
-    chart: sonatype-nexus
-    targetRevision: 5.5.0
+    repoURL: https://github.com/sonatype/nxrm3-ha-repository
+    path: nxrm-ha
+    targetRevision: 82.0.0
     helm:
       values: |
-        nexus:
-          service:
-            type: NodePort
-            annotations:
-              external-dns.alpha.kubernetes.io/hostname: nexus.leultewolde.com
-        nexusProxy:
-          env:
-            nexusHttpHost: nexus.leultewolde.com
         ingress:
           enabled: true
+          host: nexus.leultewolde.com
+          hostPath: /
           annotations:
             external-dns.alpha.kubernetes.io/hostname: nexus.leultewolde.com
-          path: /
-          pathType: Prefix
-          tls:
-            enabled: false
+        service:
+          annotations:
+            external-dns.alpha.kubernetes.io/hostname: nexus.leultewolde.com
+          nexus:
+            enabled: true
+            type: NodePort
+        statefulset:
+          replicaCount: 1
+        container:
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
       releaseName: nexus
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary
- update Argo CD Application to use Sonatype's `nxrm-ha` chart from GitHub
- mention new chart in README
- reduce Nexus CPU and memory requests and replica count for small clusters

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ee03ab868832c84c6912a3c9f0db6