### PR TITLE
Fix Nexus ingress

### DIFF
--- a/apps/nexus.yaml
+++ b/apps/nexus.yaml
@@ -16,6 +16,7 @@ spec:
           enabled: true
           host: nexus.leultewolde.com
           hostPath: /
+          defaultRule: true
           annotations:
             external-dns.alpha.kubernetes.io/hostname: nexus.leultewolde.com
         service:


### PR DESCRIPTION
## Summary
- use `defaultRule: true` for the Nexus ingress Helm chart

## Testing
- `yamllint apps/nexus.yaml`

------
https://chatgpt.com/codex/tasks/task_e_686ef2ec8664832ca3e0cf96ef9f09ba