### PR TITLE
Add isolated databases for staging and system test

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -2,6 +2,8 @@
 resources:
   - postgres-secret.yaml
   - postgres.yaml
+  - postgres-staging.yaml
+  - postgres-systemtest.yaml
   - hidmo-backend.yaml
   - hidmo-frontend.yaml
   - hidmo-backend-staging.yaml

--- a/apps/postgres-staging.yaml
+++ b/apps/postgres-staging.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres-staging
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.bitnami.com/bitnami
+    chart: postgresql
+    targetRevision: 15.5.6
+    helm:
+      values: |
+        auth:
+          username: postgres
+          database: appdb
+          existingSecret: postgres-credentials
+        primary:
+          persistence:
+            size: 1Gi
+            storageClass: local-path
+          service:
+            type: LoadBalancer
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: postgres-staging.leultewolde.com
+      releaseName: postgres-staging
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: postgres-staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/postgres-systemtest.yaml
+++ b/apps/postgres-systemtest.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres-systemtest
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.bitnami.com/bitnami
+    chart: postgresql
+    targetRevision: 15.5.6
+    helm:
+      values: |
+        auth:
+          username: postgres
+          database: appdb
+          existingSecret: postgres-credentials
+        primary:
+          persistence:
+            size: 1Gi
+            storageClass: local-path
+          service:
+            type: LoadBalancer
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: postgres-systemtest.leultewolde.com
+      releaseName: postgres-systemtest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: postgres-systemtest
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/manifests/hidmo-staging/backend/kustomization.yaml
+++ b/manifests/hidmo-staging/backend/kustomization.yaml
@@ -1,3 +1,11 @@
 namespace: hidmo-staging
 resources:
   - ../../hidmo/backend
+patchesStrategicMerge:
+  - patches/vault-token-namespace.yaml
+  - patches/dbhost/micro1-db.yaml
+  - patches/dbhost/micro1-migrate.yaml
+  - patches/dbhost/micro2-db.yaml
+  - patches/dbhost/micro2-migrate.yaml
+  - patches/dbhost/ingredients-db.yaml
+

--- a/manifests/hidmo-staging/backend/patches/dbhost/ingredients-db.yaml
+++ b/manifests/hidmo-staging/backend/patches/dbhost/ingredients-db.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ingredients-create-db
+spec:
+  template:
+    spec:
+      containers:
+        - name: create-db
+          args:
+            - "-h"
+            - "postgres-postgresql.postgres-staging.svc.cluster.local"
+            - "-U"
+            - "postgres"
+            - "-f"
+            - "/scripts/create-db.sql"

--- a/manifests/hidmo-staging/backend/patches/dbhost/micro1-db.yaml
+++ b/manifests/hidmo-staging/backend/patches/dbhost/micro1-db.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro1-create-db
+spec:
+  template:
+    spec:
+      containers:
+        - name: create-db
+          args:
+            - "-h"
+            - "postgres-postgresql.postgres-staging.svc.cluster.local"
+            - "-U"
+            - "postgres"
+            - "-f"
+            - "/scripts/create-db.sql"

--- a/manifests/hidmo-staging/backend/patches/dbhost/micro1-migrate.yaml
+++ b/manifests/hidmo-staging/backend/patches/dbhost/micro1-migrate.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro1-migrate
+spec:
+  template:
+    spec:
+      containers:
+        - name: flyway
+          env:
+            - name: FLYWAY_URL
+              value: jdbc:postgresql://postgres-postgresql.postgres-staging.svc.cluster.local:5432/micro1

--- a/manifests/hidmo-staging/backend/patches/dbhost/micro2-db.yaml
+++ b/manifests/hidmo-staging/backend/patches/dbhost/micro2-db.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro2-create-db
+spec:
+  template:
+    spec:
+      containers:
+        - name: create-db
+          args:
+            - "-h"
+            - "postgres-postgresql.postgres-staging.svc.cluster.local"
+            - "-U"
+            - "postgres"
+            - "-f"
+            - "/scripts/create-db.sql"

--- a/manifests/hidmo-staging/backend/patches/dbhost/micro2-migrate.yaml
+++ b/manifests/hidmo-staging/backend/patches/dbhost/micro2-migrate.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro2-migrate
+spec:
+  template:
+    spec:
+      containers:
+        - name: flyway
+          env:
+            - name: FLYWAY_URL
+              value: jdbc:postgresql://postgres-postgresql.postgres-staging.svc.cluster.local:5432/micro2

--- a/manifests/hidmo-staging/backend/patches/vault-token-namespace.yaml
+++ b/manifests/hidmo-staging/backend/patches/vault-token-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: vault-token
+  namespace: hidmo
+spec:
+  template:
+    metadata:
+      namespace: hidmo-staging

--- a/manifests/hidmo-systemtest/backend/kustomization.yaml
+++ b/manifests/hidmo-systemtest/backend/kustomization.yaml
@@ -1,3 +1,11 @@
 namespace: hidmo-systemtest
 resources:
   - ../../hidmo/backend
+patchesStrategicMerge:
+  - patches/vault-token-namespace.yaml
+  - patches/dbhost/micro1-db.yaml
+  - patches/dbhost/micro1-migrate.yaml
+  - patches/dbhost/micro2-db.yaml
+  - patches/dbhost/micro2-migrate.yaml
+  - patches/dbhost/ingredients-db.yaml
+

--- a/manifests/hidmo-systemtest/backend/patches/dbhost/ingredients-db.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/dbhost/ingredients-db.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ingredients-create-db
+spec:
+  template:
+    spec:
+      containers:
+        - name: create-db
+          args:
+            - "-h"
+            - "postgres-postgresql.postgres-systemtest.svc.cluster.local"
+            - "-U"
+            - "postgres"
+            - "-f"
+            - "/scripts/create-db.sql"

--- a/manifests/hidmo-systemtest/backend/patches/dbhost/micro1-db.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/dbhost/micro1-db.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro1-create-db
+spec:
+  template:
+    spec:
+      containers:
+        - name: create-db
+          args:
+            - "-h"
+            - "postgres-postgresql.postgres-systemtest.svc.cluster.local"
+            - "-U"
+            - "postgres"
+            - "-f"
+            - "/scripts/create-db.sql"

--- a/manifests/hidmo-systemtest/backend/patches/dbhost/micro1-migrate.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/dbhost/micro1-migrate.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro1-migrate
+spec:
+  template:
+    spec:
+      containers:
+        - name: flyway
+          env:
+            - name: FLYWAY_URL
+              value: jdbc:postgresql://postgres-postgresql.postgres-systemtest.svc.cluster.local:5432/micro1

--- a/manifests/hidmo-systemtest/backend/patches/dbhost/micro2-db.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/dbhost/micro2-db.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro2-create-db
+spec:
+  template:
+    spec:
+      containers:
+        - name: create-db
+          args:
+            - "-h"
+            - "postgres-postgresql.postgres-systemtest.svc.cluster.local"
+            - "-U"
+            - "postgres"
+            - "-f"
+            - "/scripts/create-db.sql"

--- a/manifests/hidmo-systemtest/backend/patches/dbhost/micro2-migrate.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/dbhost/micro2-migrate.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: micro2-migrate
+spec:
+  template:
+    spec:
+      containers:
+        - name: flyway
+          env:
+            - name: FLYWAY_URL
+              value: jdbc:postgresql://postgres-postgresql.postgres-systemtest.svc.cluster.local:5432/micro2

--- a/manifests/hidmo-systemtest/backend/patches/vault-token-namespace.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/vault-token-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: vault-token
+  namespace: hidmo
+spec:
+  template:
+    metadata:
+      namespace: hidmo-systemtest

--- a/manifests/postgres/secret/kustomization.yaml
+++ b/manifests/postgres/secret/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
   - secret.yaml
+  - staging/secret.yaml
+  - systemtest/secret.yaml

--- a/manifests/postgres/secret/staging/secret.yaml
+++ b/manifests/postgres/secret/staging/secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-credentials
+  namespace: postgres-staging
+spec:
+  encryptedData:
+    postgres-password: AgBIltZRIPBwGV87vrsKUtk+PAOZkO970HRq18vshcgA/txbgKgldfolmVZvjKNQa3E5ZNkjYlz3dVaUf6Q1RI1284KouaLwWuyCRl6lCAAiMarCuk9GHrZXlgArxAMKaxt6RPXwvmzUwFoYwQUg3hcROmrGX71doPDAMUAJnRTJvXbPHXwbukqB+a5T4mZgH+6BssGaGMfwNlYv+C0fNu0iRrffaqldgjfmZdO+NUfRAyHAJEk+sXAOaf5NzgJ8w2eble2MDDHbkjUZTplc4LsqP63O/4RJKbJiEOipI7NoWaM8Lgn+gPcwBFh6Oepsd7ZNFq4IGeFbSy+cJoZchlYYxPCVOzuFoG4NSWxLLikAKkLcPcOZt9CCMP5AoPpC4NTzb4fV6MXB6Fee6ZWgQrNLg7kYz6z8dFb8rR0lpVnGu4kd6Yph9Vwe4s4N6q8R397inr5uB3Wr8JRIMhCjrcVNj91l7ZM0abprmo2eUuvR07duwdZGo3xvxYPsbCOB2JEqTPSMHryqk1IqSVLyghwg2BVGHKwvxaPOjuYnpRk4zHcV44c7CFBFGWn9teLFLhfLDrNjFhJembKeGwvHj4rbHxFP5iCGI3par8y5JAYzbodtbTYFOwnEOZzsTvF11VLxflx1Rnl6rT7suElqgaaqK1iyNydn+tz/RMiK/PpjhGxv12M4/F/ORwHsdE/h+QBo2kv9rhQwskb6HA==
+  template:
+    metadata:
+      creationTimestamp: null
+      name: postgres-credentials
+      namespace: postgres-staging

--- a/manifests/postgres/secret/systemtest/secret.yaml
+++ b/manifests/postgres/secret/systemtest/secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: postgres-credentials
+  namespace: postgres-systemtest
+spec:
+  encryptedData:
+    postgres-password: AgBIltZRIPBwGV87vrsKUtk+PAOZkO970HRq18vshcgA/txbgKgldfolmVZvjKNQa3E5ZNkjYlz3dVaUf6Q1RI1284KouaLwWuyCRl6lCAAiMarCuk9GHrZXlgArxAMKaxt6RPXwvmzUwFoYwQUg3hcROmrGX71doPDAMUAJnRTJvXbPHXwbukqB+a5T4mZgH+6BssGaGMfwNlYv+C0fNu0iRrffaqldgjfmZdO+NUfRAyHAJEk+sXAOaf5NzgJ8w2eble2MDDHbkjUZTplc4LsqP63O/4RJKbJiEOipI7NoWaM8Lgn+gPcwBFh6Oepsd7ZNFq4IGeFbSy+cJoZchlYYxPCVOzuFoG4NSWxLLikAKkLcPcOZt9CCMP5AoPpC4NTzb4fV6MXB6Fee6ZWgQrNLg7kYz6z8dFb8rR0lpVnGu4kd6Yph9Vwe4s4N6q8R397inr5uB3Wr8JRIMhCjrcVNj91l7ZM0abprmo2eUuvR07duwdZGo3xvxYPsbCOB2JEqTPSMHryqk1IqSVLyghwg2BVGHKwvxaPOjuYnpRk4zHcV44c7CFBFGWn9teLFLhfLDrNjFhJembKeGwvHj4rbHxFP5iCGI3par8y5JAYzbodtbTYFOwnEOZzsTvF11VLxflx1Rnl6rT7suElqgaaqK1iyNydn+tz/RMiK/PpjhGxv12M4/F/ORwHsdE/h+QBo2kv9rhQwskb6HA==
+  template:
+    metadata:
+      creationTimestamp: null
+      name: postgres-credentials
+      namespace: postgres-systemtest


### PR DESCRIPTION
## Summary
- deploy dedicated Postgres instances for staging and systemtest
- expose postgres secrets in new namespaces
- apply vault token secret to staging and systemtest
- point systemtest and staging jobs at their own Postgres services

## Testing
- `kustomize build manifests/hidmo-staging/backend`
- `kustomize build manifests/hidmo-systemtest/backend`
- `kustomize build manifests/postgres/secret`

------
https://chatgpt.com/codex/tasks/task_e_686f040cfd70832c8b03bf43b4bbc669