### PR TITLE
Add VaultAuth resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Create the following secrets in HashiCorp Vault under the `kv` engine. Argo's Va
 | `secret/postgres-systemtest/postgres-credentials` | `postgres-credentials` | `postgres-password` |
 | `secret/sonarqube/monitoring` | `sonarqube-monitoring` | `passcode` |
 
-Each namespace also requires a `VaultConnection` named `my-vault-connection` so
-Vault secrets can be synced. Example:
+Each namespace also requires a `VaultConnection` named `my-vault-connection` and
+a corresponding `VaultAuth` so Vault secrets can be synced. Example connection:
 
 ```yaml
 apiVersion: secrets.hashicorp.com/v1beta1
@@ -45,6 +45,23 @@ metadata:
 spec:
   address: https://vault.leultewolde.com
   skipTLSVerify: false
+```
+
+Example `VaultAuth` referencing that connection:
+
+```yaml
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: my-vault-connection
+  namespace: <namespace>
+spec:
+  vaultConnectionRef: my-vault-connection
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: demo
+    serviceAccount: default
 ```
 ## Bootstrap
 

--- a/manifests/hidmo/backend/kustomization.yaml
+++ b/manifests/hidmo/backend/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - vault-token.yaml
   - postgres-credentials.yaml
   - vault-connection.yaml
+  - vault-auth.yaml

--- a/manifests/hidmo/backend/vault-auth.yaml
+++ b/manifests/hidmo/backend/vault-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: my-vault-connection
+  namespace: hidmo
+spec:
+  vaultConnectionRef: my-vault-connection
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: demo
+    serviceAccount: default

--- a/manifests/postgres/secret/kustomization.yaml
+++ b/manifests/postgres/secret/kustomization.yaml
@@ -3,5 +3,8 @@ resources:
   - staging/secret.yaml
   - systemtest/secret.yaml
   - vault-connection.yaml
+  - vault-auth.yaml
   - staging/vault-connection.yaml
+  - staging/vault-auth.yaml
   - systemtest/vault-connection.yaml
+  - systemtest/vault-auth.yaml

--- a/manifests/postgres/secret/staging/vault-auth.yaml
+++ b/manifests/postgres/secret/staging/vault-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: my-vault-connection
+  namespace: postgres-staging
+spec:
+  vaultConnectionRef: my-vault-connection
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: demo
+    serviceAccount: default

--- a/manifests/postgres/secret/systemtest/vault-auth.yaml
+++ b/manifests/postgres/secret/systemtest/vault-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: my-vault-connection
+  namespace: postgres-systemtest
+spec:
+  vaultConnectionRef: my-vault-connection
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: demo
+    serviceAccount: default

--- a/manifests/postgres/secret/vault-auth.yaml
+++ b/manifests/postgres/secret/vault-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: my-vault-connection
+  namespace: postgres
+spec:
+  vaultConnectionRef: my-vault-connection
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: demo
+    serviceAccount: default

--- a/manifests/sonarqube/secret/kustomization.yaml
+++ b/manifests/sonarqube/secret/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - secret.yaml
   - vault-connection.yaml
+  - vault-auth.yaml

--- a/manifests/sonarqube/secret/vault-auth.yaml
+++ b/manifests/sonarqube/secret/vault-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: my-vault-connection
+  namespace: sonarqube
+spec:
+  vaultConnectionRef: my-vault-connection
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: demo
+    serviceAccount: default


### PR DESCRIPTION
## Summary
- add VaultAuth manifests for hidmo backend, postgres, and sonarqube
- update kustomization files
- document VaultAuth requirements in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f1be118c8832ca7688ada07c826bb