### PR TITLE
Add spring profiles for microservices

### DIFF
--- a/manifests/hidmo-staging/backend/kustomization.yaml
+++ b/manifests/hidmo-staging/backend/kustomization.yaml
@@ -6,4 +6,6 @@ patchesStrategicMerge:
   # - patches/dbhost/micro1-migrate.yaml
   - patches/dbhost/ingredients-db.yaml
   - patches/ingress-host.yaml
+  - patches/external-service-spring-profile.yaml
+  - patches/ingredients-service-spring-profile.yaml
 

--- a/manifests/hidmo-staging/backend/patches/external-service-spring-profile.yaml
+++ b/manifests/hidmo-staging/backend/patches/external-service-spring-profile.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: external-service
+        env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: "staging"

--- a/manifests/hidmo-staging/backend/patches/ingredients-service-spring-profile.yaml
+++ b/manifests/hidmo-staging/backend/patches/ingredients-service-spring-profile.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: km-ingredients-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: km-ingredients-service
+        env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: "staging"

--- a/manifests/hidmo-systemtest/backend/kustomization.yaml
+++ b/manifests/hidmo-systemtest/backend/kustomization.yaml
@@ -6,4 +6,6 @@ patchesStrategicMerge:
   # - patches/dbhost/micro1-migrate.yaml
   - patches/dbhost/ingredients-db.yaml
   - patches/ingress-host.yaml
+  - patches/external-service-spring-profile.yaml
+  - patches/ingredients-service-spring-profile.yaml
 

--- a/manifests/hidmo-systemtest/backend/patches/external-service-spring-profile.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/external-service-spring-profile.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: external-service
+        env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: "systemtest"

--- a/manifests/hidmo-systemtest/backend/patches/ingredients-service-spring-profile.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/ingredients-service-spring-profile.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: km-ingredients-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: km-ingredients-service
+        env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: "systemtest"


### PR DESCRIPTION
## Summary
- add kustomize patches to change `SPRING_PROFILES_ACTIVE` for external-service and ingredients-service
- include these patches in systemtest and staging overlays

## Testing
- `kustomize build manifests/hidmo-systemtest/backend | head -n 20`
- `kustomize build manifests/hidmo-staging/backend | head -n 20`
- `kustomize build manifests/hidmo/backend | grep -A1 SPRING_PROFILES_ACTIVE`


------
https://chatgpt.com/codex/tasks/task_e_687033786f98832cacb51f60b435abb8