### PR TITLE
Configure vault token paths for staging and systemtest

### DIFF
--- a/manifests/hidmo-staging/backend/kustomization.yaml
+++ b/manifests/hidmo-staging/backend/kustomization.yaml
@@ -8,4 +8,5 @@ patchesStrategicMerge:
   - patches/ingress-host.yaml
   - patches/external-service-spring-profile.yaml
   - patches/ingredients-service-spring-profile.yaml
+  - patches/vault-token-path.yaml
 

--- a/manifests/hidmo-staging/backend/patches/vault-token-path.yaml
+++ b/manifests/hidmo-staging/backend/patches/vault-token-path.yaml
@@ -1,0 +1,6 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: vault-token
+spec:
+  path: hidmo/kitchen/backend/staging

--- a/manifests/hidmo-systemtest/backend/kustomization.yaml
+++ b/manifests/hidmo-systemtest/backend/kustomization.yaml
@@ -8,4 +8,5 @@ patchesStrategicMerge:
   - patches/ingress-host.yaml
   - patches/external-service-spring-profile.yaml
   - patches/ingredients-service-spring-profile.yaml
+  - patches/vault-token-path.yaml
 

--- a/manifests/hidmo-systemtest/backend/patches/vault-token-path.yaml
+++ b/manifests/hidmo-systemtest/backend/patches/vault-token-path.yaml
@@ -1,0 +1,6 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: vault-token
+spec:
+  path: hidmo/kitchen/backend/systemtest


### PR DESCRIPTION
## Summary
- add VaultStaticSecret patches to point to environment-specific paths
- include new patches in staging and systemtest kustomizations

## Testing
- `kustomize build manifests/hidmo-staging/backend`
- `kustomize build manifests/hidmo-systemtest/backend`


------
https://chatgpt.com/codex/tasks/task_e_687058d1e4ac832cbb84d02c4a0ae79d