### PR TITLE
Add CPU resources to backend deployments

### DIFF
--- a/manifests/hidmo/backend/deployment.yaml
+++ b/manifests/hidmo/backend/deployment.yaml
@@ -25,6 +25,13 @@ spec:
               value: "127.0.0.1:8001"
             - name: KONG_STATUS_LISTEN
               value: "0.0.0.0:8100"
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "400m"
+              memory: "1536Mi"
           volumeMounts:
             - name: kong-config
               mountPath: /etc/kong

--- a/manifests/hidmo/backend/microservices/external-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/external-service/deployment.yaml
@@ -28,6 +28,13 @@ spec:
                 secretKeyRef:
                   name: backend-secrets
                   key: vault-token
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "200m"
+              memory: "768Mi"
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness

--- a/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
@@ -71,10 +71,17 @@ spec:
                 secretKeyRef:
                   name: backend-secrets
                   key: splunk-token
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: 8001
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "512Mi"
+          limits:
+            cpu: "400m"
+            memory: "1024Mi"
+        livenessProbe:
+          httpGet:
+            path: /actuator/health/liveness
+            port: 8001
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5

--- a/manifests/hidmo/backend/microservices/micro1/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/micro1/deployment.yaml
@@ -20,3 +20,10 @@ spec:
             - "-listen=:5678"
           ports:
             - containerPort: 5678
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"


### PR DESCRIPTION
## Summary
- set CPU and memory requests/limits for Kong container
- add CPU and memory resources for external-service, ingredients-service and micro1 microservices

## Testing
- `git diff --color --stat`

------
https://chatgpt.com/codex/tasks/task_e_687163333ae0832cad2df6b43242934b