### PR TITLE
Fix external service port

### DIFF
--- a/manifests/hidmo/backend/microservices/external-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/external-service/deployment.yaml
@@ -17,7 +17,7 @@ spec:
           image: docker.io/ivtheforth/external-service:latest
           imagePullPolicy: Always
           ports:
-            - containerPort: 8001
+            - containerPort: 8080
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"


### PR DESCRIPTION
## Summary
- fix container port in external service deployment so readiness/liveness and service port match

## Testing
- `kustomize build manifests/hidmo/backend`
- `kustomize build manifests/hidmo/backend/microservices/external-service`

------
https://chatgpt.com/codex/tasks/task_e_68718b3111c4832ca6eb142019152b0c