### PR TITLE
Increase ingredients-service memory limit

### DIFF
--- a/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
@@ -69,10 +69,10 @@ spec:
           resources:
             requests:
               cpu: "400m"
-              memory: "1024Mi"
+              memory: "2048Mi"
             limits:
               cpu: "800m"
-              memory: "2048Mi"
+              memory: "4096Mi"
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness


### PR DESCRIPTION
## Summary
- bump memory requests and limits for `km-ingredients-service` deployment

## Testing
- `kustomize build manifests/hidmo/backend/microservices/ingredients-service`

------
https://chatgpt.com/codex/tasks/task_e_6871a40f40e0832c85a332f461a7e5c3