### PR TITLE
Reduce ingredients service memory usage

### DIFF
--- a/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/ingredients-service/deployment.yaml
@@ -19,6 +19,8 @@ spec:
           ports:
             - containerPort: 8001
           env:
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xmx512m -Xms512m"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
             - name: NEW_RELIC_LICENSE_KEY
@@ -69,10 +71,10 @@ spec:
           resources:
             requests:
               cpu: "400m"
-              memory: "2048Mi"
+              memory: "512Mi"
             limits:
               cpu: "800m"
-              memory: "4096Mi"
+              memory: "1024Mi"
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness


### PR DESCRIPTION
## Summary
- lower memory request/limit for km-ingredients-service
- restore `JAVA_TOOL_OPTIONS` to set fixed heap size

## Testing
- `kustomize build manifests/hidmo/backend | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6871ba77f930832cb9493e22ac9fcd88