### PR TITLE
Enable OIDC auth for ArgoCD and SonarQube

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Create the following secrets in HashiCorp Vault under the `kv` engine. Argo's Va
 | `secret/postgres-staging/postgres-credentials` | `postgres-credentials` | `postgres-password` |
 | `secret/postgres-systemtest/postgres-credentials` | `postgres-credentials` | `postgres-password` |
 | `secret/sonarqube/monitoring` | `sonarqube-monitoring` | `passcode` |
+| `secret/sonarqube/oidc` | `sonarqube-oidc` | `secret.properties` |
+| `secret/argocd/oidc` | `argocd-secret` | `oidc.keycloak.clientSecret` |
 
 Each namespace also requires a `VaultConnection` named `my-vault-connection` and
 a corresponding `VaultAuth` so Vault secrets can be synced. Example connection:

--- a/apps/argocd-oidc.yaml
+++ b/apps/argocd-oidc.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-oidc
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
+    targetRevision: HEAD
+    path: manifests/argocd
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - sonarqube-secret.yaml
   - sonarqube.yaml
   - vault.yaml
+  - argocd-oidc.yaml

--- a/apps/sonarqube.yaml
+++ b/apps/sonarqube.yaml
@@ -27,6 +27,11 @@ spec:
             enabled: true
             storageClass: local-path
             size: 5Gi
+        sonarProperties:
+          sonar.auth.oidc.enabled: "true"
+          sonar.auth.oidc.issuerUri: https://auth.leultewolde.com/realms/hidmo
+          sonar.auth.oidc.clientId: sonarqube-client
+        sonarSecretProperties: sonarqube-oidc
         monitoringPasscodeSecretName: sonarqube-monitoring
         monitoringPasscodeSecretKey: passcode
       releaseName: sonarqube

--- a/manifests/argocd/configmap.yaml
+++ b/manifests/argocd/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  oidc.config: |
+    name: Keycloak
+    issuer: https://auth.leultewolde.com/realms/hidmo
+    clientID: argocd-client
+    clientSecret: $oidc.keycloak.clientSecret
+    requestedScopes: ["openid", "profile", "email", "groups"]

--- a/manifests/argocd/kustomization.yaml
+++ b/manifests/argocd/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
+  - configmap.yaml
   - secret.yaml
-  - keycloak-secret.yaml
   - vault-connection.yaml
   - vault-auth.yaml

--- a/manifests/argocd/secret.yaml
+++ b/manifests/argocd/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: argocd-oidc
+  namespace: argocd
+spec:
+  vaultAuthRef: my-vault-connection
+  mount: secret
+  path: argocd/oidc
+  type: kv-v2
+  destination:
+    create: true
+    name: argocd-secret
+    overwrite: true

--- a/manifests/argocd/vault-auth.yaml
+++ b/manifests/argocd/vault-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: my-vault-connection
+  namespace: argocd
+spec:
+  vaultConnectionRef: my-vault-connection
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: universal-role
+    serviceAccount: default

--- a/manifests/argocd/vault-connection.yaml
+++ b/manifests/argocd/vault-connection.yaml
@@ -1,0 +1,8 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultConnection
+metadata:
+  name: my-vault-connection
+  namespace: argocd
+spec:
+  address: https://vault.leultewolde.com
+  skipTLSVerify: false

--- a/manifests/sonarqube/secret/keycloak-secret.yaml
+++ b/manifests/sonarqube/secret/keycloak-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: sonarqube-oidc
+  namespace: sonarqube
+spec:
+  vaultAuthRef: my-vault-connection
+  mount: secret
+  path: sonarqube/oidc
+  type: kv-v2
+  destination:
+    create: true
+    name: sonarqube-oidc


### PR DESCRIPTION
## Summary
- add OIDC settings for SonarQube
- add Vault secret for SonarQube OIDC
- deploy ArgoCD OIDC config and secret via Vault
- include new apps in kustomization
- document Vault paths for OIDC secrets

## Testing
- `kustomize build manifests/argocd | head`
- `kustomize build manifests/sonarqube/secret | head`
- `kustomize build apps >/tmp/build.yaml && head -n 20 /tmp/build.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6883ddbbae58832c82601a9a21c55867