### PR TITLE
Configure SonarQube OIDC login

### DIFF
--- a/apps/sonarqube.yaml
+++ b/apps/sonarqube.yaml
@@ -17,6 +17,9 @@ spec:
           enabled: true
           storageClass: local-path
           size: 5Gi
+        plugins:
+          install:
+            - https://github.com/sonar-auth-oidc/sonar-auth-oidc/releases/download/v3.0.0/sonar-auth-oidc-plugin-3.0.0.jar
         service:
           type: LoadBalancer
           annotations:
@@ -30,6 +33,7 @@ spec:
         monitoringPasscodeSecretName: sonarqube-monitoring
         monitoringPasscodeSecretKey: passcode
         sonarProperties:
+          sonar.core.serverBaseURL: https://sonar.leultewolde.com
           sonar.auth.oidc.enabled: "true"
           sonar.auth.oidc.issuerUri: https://auth.leultewolde.com/realms/hidmo
           sonar.auth.oidc.clientId: sonarqube-client


### PR DESCRIPTION
## Summary
- install the sonar-auth-oidc plugin when deploying SonarQube
- configure `sonar.core.serverBaseURL`

## Testing
- `yamllint apps/sonarqube.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6883f5bbe1e8832c86e0ccab286a3550