### PR TITLE
Configure SonarQube OIDC login

### DIFF
--- a/apps/sonarqube.yaml
+++ b/apps/sonarqube.yaml
@@ -17,6 +17,9 @@ spec:
           enabled: true
           storageClass: local-path
           size: 5Gi
+        plugins:
+          install:
+            - https://github.com/sonar-auth-oidc/sonar-auth-oidc/releases/download/v3.0.0/sonar-auth-oidc-plugin-3.0.0.jar
         service:
           type: LoadBalancer
           annotations:
@@ -30,9 +33,12 @@ spec:
         monitoringPasscodeSecretName: sonarqube-monitoring
         monitoringPasscodeSecretKey: passcode
         sonarProperties:
+          sonar.core.serverBaseURL: https://sonar.leultewolde.com
           sonar.auth.oidc.enabled: "true"
           sonar.auth.oidc.issuerUri: https://auth.leultewolde.com/realms/hidmo
           sonar.auth.oidc.clientId: sonarqube-client
+          sonar.forceAuthentication: "true"
+        sonarSecretProperties: sonarqube-oidc
         env:
           - name: SONAR_AUTH_OIDC_CLIENT_SECRET
             valueFrom:

--- a/manifests/sonarqube/secret/oidc-secret.yaml
+++ b/manifests/sonarqube/secret/oidc-secret.yaml
@@ -11,3 +11,6 @@ spec:
   destination:
     create: true
     name: sonarqube-oidc
+    templates:
+      secret.properties: |
+        sonar.auth.oidc.clientSecret={{ .client-secret }}


### PR DESCRIPTION
## Summary
- install the sonar-auth-oidc plugin when deploying SonarQube
- configure `sonar.core.serverBaseURL`
- add secret template for OIDC `clientSecret`
- load secret properties and force authentication for OIDC

## Testing
- `yamllint apps/sonarqube.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6883f5bbe1e8832c86e0ccab286a3550