### PR TITLE
Fix SonarQube OIDC secret template

### DIFF
--- a/manifests/sonarqube/secret/oidc-secret.yaml
+++ b/manifests/sonarqube/secret/oidc-secret.yaml
@@ -14,4 +14,4 @@ spec:
     templates:
       secret.properties:
         text: |
-          sonar.auth.oidc.clientSecret={{ .client-secret }}
+          sonar.auth.oidc.clientSecret={{ index . "client-secret" }}


### PR DESCRIPTION
## Summary
- use `templates` under `destination` for `sonarqube-oidc`
- reference the Vault key with `index . "client-secret"`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688400b1101c832c9ce5a2258a457cad