### PR TITLE
Fix frontend env variable expansion

### DIFF
--- a/manifests/hidmo/frontend/deployment.yaml
+++ b/manifests/hidmo/frontend/deployment.yaml
@@ -18,7 +18,7 @@ spec:
           command: ["sh", "-c"]
           args:
             - |
-              cat <<'EOF' > /env/env.js
+              cat <<EOF > /env/env.js
               window._env_ = {
                 VITE_API_URL: "$VITE_API_URL",
                 VITE_RELEASE_API_URL: "$VITE_RELEASE_API_URL",


### PR DESCRIPTION
## Summary
- ensure frontend deployment expands env vars when generating env.js

## Testing
- `make test` *(fails: yamllint errors)*
- `make validate` *(fails: see make_validate.log)*
- `make dry-run` *(fails: Docker daemon missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d6bc8cc3c832c86144fc585bd6af0