### PR TITLE
Fix frontend env expansion via envsubst

### DIFF
--- a/manifests/hidmo/frontend/deployment.yaml
+++ b/manifests/hidmo/frontend/deployment.yaml
@@ -18,7 +18,7 @@ spec:
           command: ["sh", "-c"]
           args:
             - |
-              cat <<'EOF' > /env/env.js
+              cat <<'EOF' > /env/env.js.template
               window._env_ = {
                 VITE_API_URL: "$VITE_API_URL",
                 VITE_RELEASE_API_URL: "$VITE_RELEASE_API_URL",
@@ -29,6 +29,7 @@ spec:
                 VITE_GITHUB_CLIENT_SECRET: "$VITE_GITHUB_CLIENT_SECRET"
               };
               EOF
+              envsubst < /env/env.js.template > /env/env.js
           env:
             - name: VITE_API_URL
               value: "https://api-hidmo.leultewolde.com/kitchen/stored-items"


### PR DESCRIPTION
## Summary
- ensure frontend env.js is generated using envsubst for variable expansion

## Testing
- `make test` *(fails: yamllint missing)*
- `make validate` *(fails: kubeconform missing)*
- `make dry-run` *(fails: k3d missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d6bc8cc3c832c86144fc585bd6af0