### PR TITLE
Render frontend env.js using envsubst

### DIFF
--- a/manifests/hidmo/frontend/deployment.yaml
+++ b/manifests/hidmo/frontend/deployment.yaml
@@ -14,11 +14,13 @@ spec:
     spec:
       initContainers:
         - name: generate-env
-          image: busybox:1.36
-          command: ["sh", "-c"]
+          image: alpine:3.20
+          command: ["/bin/sh", "-c"]
           args:
             - |
-              cat <<'EOF' > /env/env.js
+              set -e
+              apk add --no-cache gettext >/dev/null
+              cat <<'EOF' > /env/env.js.template
               window._env_ = {
                 VITE_API_URL: "$VITE_API_URL",
                 VITE_RELEASE_API_URL: "$VITE_RELEASE_API_URL",
@@ -29,6 +31,7 @@ spec:
                 VITE_GITHUB_CLIENT_SECRET: "$VITE_GITHUB_CLIENT_SECRET"
               };
               EOF
+              envsubst < /env/env.js.template > /env/env.js
           env:
             - name: VITE_API_URL
               value: "https://api-hidmo.leultewolde.com/kitchen/stored-items"


### PR DESCRIPTION
## Summary
- expand frontend environment variables via envsubst in init container

## Testing
- `make test` *(fails: yamllint errors)*
- `make validate` *(fails: kubeconform error)*
- `make dry-run` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_688d6bc8cc3c832c86144fc585bd6af0