### PR TITLE
feat: add hidmo-web static site deployment

### DIFF
--- a/apps/hidmo-web.yaml
+++ b/apps/hidmo-web.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hidmo-web
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/leultewolde/hidmo-argo-gitops.git
+    targetRevision: HEAD
+    path: manifests/hidmo-web/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hidmo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # - postgres-systemtest.yaml
   - hidmo-backend.yaml
   - hidmo-frontend.yaml
+  - hidmo-web.yaml
   # - hidmo-backend-staging.yaml
   # - hidmo-frontend-staging.yaml
   # - hidmo-backend-systemtest.yaml

--- a/manifests/hidmo-web/base/deployment.yaml
+++ b/manifests/hidmo-web/base/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hidmo-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hidmo-web
+  template:
+    metadata:
+      labels:
+        app: hidmo-web
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: static
+              mountPath: /usr/share/nginx/html
+      volumes:
+        - name: static
+          persistentVolumeClaim:
+            claimName: hidmo-web-pvc

--- a/manifests/hidmo-web/base/ingress.yaml
+++ b/manifests/hidmo-web/base/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hidmo-web
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      try_files $uri $uri/ /index.html;
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hidmo-web
+                port:
+                  number: 80

--- a/manifests/hidmo-web/base/kustomization.yaml
+++ b/manifests/hidmo-web/base/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/manifests/hidmo-web/base/pvc.yaml
+++ b/manifests/hidmo-web/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hidmo-web-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/manifests/hidmo-web/base/service.yaml
+++ b/manifests/hidmo-web/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hidmo-web
+spec:
+  selector:
+    app: hidmo-web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/manifests/hidmo-web/overlays/prod/ingress-patch.yaml
+++ b/manifests/hidmo-web/overlays/prod/ingress-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hidmo-web
+spec:
+  tls:
+    - hosts:
+        - hidmo.leultewolde.com
+      secretName: hidmo-web-tls
+  rules:
+    - host: hidmo.leultewolde.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hidmo-web
+                port:
+                  number: 80

--- a/manifests/hidmo-web/overlays/prod/kustomization.yaml
+++ b/manifests/hidmo-web/overlays/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - ingress-patch.yaml


### PR DESCRIPTION
## Summary
- add Kustomize base for hidmo-web static site with PVC, NGINX and ingress
- overlay prod patch for hidmo.leultewolde.com with TLS
- register hidmo-web ArgoCD application

## Testing
- `kustomize build manifests/hidmo-web/base`
- `kustomize build manifests/hidmo-web/overlays/prod`

------
https://chatgpt.com/codex/tasks/task_e_6891456e3bdc832cb04aa9d2089d400a