### PR TITLE
feat: add kafka for release events

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ affected by invalid configuration.
   - Sonatype Nexus Repository Pro is reachable at `nexus.leultewolde.com` for storing artifacts via Sonatype's `nxrm-ha` Helm chart
 - HashiCorp Vault UI is reachable at `vault.leultewolde.com` for managing secrets
 - Argo Image Updater keeps `km-ingredients-service` up to date automatically via git write-back.
+- Kafka broker available at the `kafka` service exposes topics for release, build, and notification events
+
+## Kafka Events
+
+A single-node Kafka broker runs inside the cluster and is reachable at the
+`kafka` service on port `9092`. The release management service publishes
+messages to two topics:
+
+- `release.events.v1` (key: `releaseId`)
+- `build.events.v1` (key: `buildId` or `releaseId` for co-partitioning)
+
+The `notifications.outcomes.v1` topic is also created for downstream analytics.
+
+Other services can consume or produce these events by configuring the following
+environment variables:
+
+| Variable | Value |
+|----------|-------|
+| `KAFKA_BOOTSTRAP_SERVERS` | `kafka:9092` |
+| `KAFKA_RELEASE_EVENTS_TOPIC` | `release.events.v1` |
+| `KAFKA_BUILD_EVENTS_TOPIC` | `build.events.v1` |
+| `KAFKA_NOTIFICATIONS_OUTCOMES_TOPIC` | `notifications.outcomes.v1` |
 
 ## Vault Secrets
 

--- a/manifests/hidmo/backend/kustomization.yaml
+++ b/manifests/hidmo/backend/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - microservices/ingredients-service
   - microservices/external-service
   - microservices/release-management
+  - microservices/kafka
   - vault-token.yaml
   - vault-connection.yaml
   - vault-auth.yaml

--- a/manifests/hidmo/backend/microservices/kafka/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/kafka/deployment.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: bitnami/kafka:3.6.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9092
+          env:
+            - name: KAFKA_ENABLE_KRAFT
+              value: "yes"
+            - name: KAFKA_CFG_NODE_ID
+              value: "0"
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: broker,controller
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: "0@kafka:9093"
+            - name: KAFKA_CFG_LISTENERS
+              value: PLAINTEXT://:9092,CONTROLLER://:9093
+            - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
+              value: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: CONTROLLER
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
+              value: PLAINTEXT://kafka:9092
+            - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"

--- a/manifests/hidmo/backend/microservices/kafka/kustomization.yaml
+++ b/manifests/hidmo/backend/microservices/kafka/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+resources:
+  - deployment.yaml
+  - service.yaml
+  - topics-job.yaml

--- a/manifests/hidmo/backend/microservices/kafka/service.yaml
+++ b/manifests/hidmo/backend/microservices/kafka/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+spec:
+  selector:
+    app: kafka
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: 9092

--- a/manifests/hidmo/backend/microservices/kafka/topics-job.yaml
+++ b/manifests/hidmo/backend/microservices/kafka/topics-job.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kafka-create-topics
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: create-topics
+          image: bitnami/kafka:3.6.0
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              kafka-topics.sh --bootstrap-server kafka:9092 \
+                --create --if-not-exists --topic release.events.v1
+              kafka-topics.sh --bootstrap-server kafka:9092 \
+                --create --if-not-exists --topic build.events.v1
+              kafka-topics.sh --bootstrap-server kafka:9092 \
+                --create --if-not-exists --topic notifications.outcomes.v1

--- a/manifests/hidmo/backend/microservices/release-management/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/release-management/deployment.yaml
@@ -61,6 +61,12 @@ spec:
                 secretKeyRef:
                   name: backend-secrets
                   key: splunk-hec-token
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka:9092"
+            - name: KAFKA_RELEASE_EVENTS_TOPIC
+              value: "release.events.v1"
+            - name: KAFKA_BUILD_EVENTS_TOPIC
+              value: "build.events.v1"
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness


### PR DESCRIPTION
## Summary
- add single-node Kafka broker and create topics for release events
- publish event topic names via release-management service configuration
- document Kafka setup and environment variables for consumers

## Testing
- `make test` *(fails: line-length errors in existing manifests)*
- `kubeconform -summary manifests/hidmo/backend/microservices/kafka/deployment.yaml manifests/hidmo/backend/microservices/kafka/service.yaml manifests/hidmo/backend/microservices/kafka/topics-job.yaml manifests/hidmo/backend/microservices/release-management/deployment.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689f8537cee0832cb5240ab3fa960f0e