### PR TITLE
Add notification service with database

### DIFF
--- a/manifests/hidmo/backend/kong-config.yaml
+++ b/manifests/hidmo/backend/kong-config.yaml
@@ -35,3 +35,10 @@ data:
             paths:
               - /release-management
             strip_path: true
+      - name: notification-service
+        url: http://notification-service:8080
+        routes:
+          - name: notification-service
+            paths:
+              - /notifications
+            strip_path: true

--- a/manifests/hidmo/backend/kustomization.yaml
+++ b/manifests/hidmo/backend/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - microservices/ingredients-service
   - microservices/external-service
   - microservices/release-management
+  - microservices/notification-service
   - microservices/kafka
   - vault-token.yaml
   - vault-connection.yaml

--- a/manifests/hidmo/backend/microservices/notification-service/db-job.yaml
+++ b/manifests/hidmo/backend/microservices/notification-service/db-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: notification-service-create-db
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: create-db
+          image: postgres:15
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secrets
+                  key: db-password
+          command: ["psql"]
+          args:
+            - "-h"
+            - "postgres-postgresql.postgres.svc.cluster.local"
+            - "-U"
+            - "postgres"
+            - "-f"
+            - "/scripts/create-db.sql"
+          volumeMounts:
+            - name: db-script
+              mountPath: /scripts
+      volumes:
+        - name: db-script
+          configMap:
+            name: notification-service-create-db

--- a/manifests/hidmo/backend/microservices/notification-service/deployment.yaml
+++ b/manifests/hidmo/backend/microservices/notification-service/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-service
+  template:
+    metadata:
+      labels:
+        app: notification-service
+    spec:
+      containers:
+        - name: notification-service
+          image: docker.io/ivtheforth/notification-service:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secrets
+                  key: db-url
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secrets
+                  key: db-user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secrets
+                  key: db-password
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: "400m"
+              memory: "512Mi"
+            limits:
+              cpu: "800m"
+              memory: "1024Mi"

--- a/manifests/hidmo/backend/microservices/notification-service/kustomization.yaml
+++ b/manifests/hidmo/backend/microservices/notification-service/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+- deployment.yaml
+- service.yaml
+- db-job.yaml
+- scaledobject.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: notification-service-create-db
+  files:
+  - sql/create-db.sql

--- a/manifests/hidmo/backend/microservices/notification-service/scaledobject.yaml
+++ b/manifests/hidmo/backend/microservices/notification-service/scaledobject.yaml
@@ -1,0 +1,16 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: notification-service-scaledobject
+spec:
+  scaleTargetRef:
+    name: notification-service
+  minReplicaCount: 1
+  maxReplicaCount: 3
+  cooldownPeriod: 30
+  pollingInterval: 15
+  triggers:
+  - type: cpu
+    metadata:
+      type: Utilization
+      value: "50"

--- a/manifests/hidmo/backend/microservices/notification-service/service.yaml
+++ b/manifests/hidmo/backend/microservices/notification-service/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+spec:
+  selector:
+    app: notification-service
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/manifests/hidmo/backend/microservices/notification-service/sql/create-db.sql
+++ b/manifests/hidmo/backend/microservices/notification-service/sql/create-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE notification_db;


### PR DESCRIPTION
## Summary
- add notification-service microservice manifests with database job
- wire notification-service into backend kustomization

## Testing
- `make lint` *(fails: yamllint reported multiple issues across repository)*
- `make validate` *(fails: kubeconform could not find schemas for several resources)*
- `make dry-run` *(fails: k3d could not connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689fcf4c2c48832cb6645440cdaf8875